### PR TITLE
Fix comment style in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-// Corresponding Dockerfile: https://github.com/JabRef/jabref/blob/main/Dockerfile.jabkit 
+# Corresponding Dockerfile: https://github.com/JabRef/jabref/blob/main/Dockerfile.jabkit
 FROM ghcr.io/jabref/jabkit:edge
 
 ENTRYPOINT ["/jabref/jabkit/bin/jabkit"]


### PR DESCRIPTION
Comments in Dockerfiles start with `#` instead of `//`.

Resulting error can be seen for example in https://github.com/JabRef/jabref-action/actions/runs/18560395771/job/52907702898
```
Dockerfile:1
  --------------------
     1 | >>> // Corresponding Dockerfile: https://github.com/JabRef/jabref/blob/main/Dockerfile.jabkit 
     2 |     FROM ghcr.io/jabref/jabkit:edge
     3 |     
  --------------------
  ERROR: failed to build: failed to solve: dockerfile parse error on line 1: unknown instruction: //
```